### PR TITLE
Remove overriding adapter name

### DIFF
--- a/lib/active_record/connection_adapters/mysql2_annotator_adapter.rb
+++ b/lib/active_record/connection_adapters/mysql2_annotator_adapter.rb
@@ -32,8 +32,6 @@ module ActiveRecord
 
   module ConnectionAdapters
     class Mysql2AnnotatorAdapter < Mysql2Adapter
-      ADAPTER_NAME = "Mysql2Annotator".freeze
-
       def annotation
         @annotation
       end


### PR DESCRIPTION
Remove overriding adapter name so it uses the active record name whih is Mysql2

Signed-off-by: Oky Sabeni <okysabeni@mavenlink.com>