### PR TITLE
pass only :message parameter to exception initializer

### DIFF
--- a/lib/active_record/connection_adapters/mysql2_annotator_adapter.rb
+++ b/lib/active_record/connection_adapters/mysql2_annotator_adapter.rb
@@ -22,7 +22,7 @@ module ActiveRecord
         ConnectionAdapters::Mysql2AnnotatorAdapter.new(client, logger, options, config)
       rescue Mysql2::Error => error
         if error.message.include?("Unknown database")
-          raise ActiveRecord::NoDatabaseError.new(error.message, error)
+          raise ActiveRecord::NoDatabaseError.new(error.message)
         else
           raise
         end


### PR DESCRIPTION
I need to work through some specs on this but the gist is

# before fix

```
  1) DbAnnotator has a version number                                                      
     Got 0 failures and 2 other errors:                                                                                      
                                                                                                                   
     1.1) Failure/Error: raise ActiveRecord::NoDatabaseError.new(error.message, error)                                                                    
                                                                                                                            
          ArgumentError:                                                                                                     
            wrong number of arguments (given 2, expected 0..1)                                 
          # ./vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.4.4/lib/active_record/errors.rb:100:in `initialize'
          # ./lib/active_record/connection_adapters/mysql2_annotator_adapter.rb:25:in `new'
          # ./lib/active_record/connection_adapters/mysql2_annotator_adapter.rb:25:in `rescue in mysql2_annotator_connection'
          # ./lib/active_record/connection_adapters/mysql2_annotator_adapter.rb:11:in `mysql2_annotator_connection'
          # ./spec/spec_helper.rb:12:in `new_client'                                            
          # ./spec/spec_helper.rb:25:in `block (2 levels) in <top (required)>'                                               
          # ------------------                                                                                     
          # --- Caused by: ---                                                             
          # Mysql2::Error:                                                                                                   
          #   Unknown database 'test_anno_db'
          #   ./vendor/bundle/ruby/2.5.0/gems/mysql2-0.5.3/lib/mysql2/client.rb:90:in `connect'
  ```
  
  # after fix
  
  ```
    1) DbAnnotator has a version number                                          
     Got 0 failures and 2 other errors:                                                                                      
                                                                                                                   
     1.1) Failure/Error: raise ActiveRecord::NoDatabaseError.new(error.message)
                                                                                                                             
          ActiveRecord::NoDatabaseError:                                                                           
            Unknown database 'test_anno_db'                     
          # ./lib/active_record/connection_adapters/mysql2_annotator_adapter.rb:25:in `rescue in mysql2_annotator_connection'
          # ./lib/active_record/connection_adapters/mysql2_annotator_adapter.rb:11:in `mysql2_annotator_connection'
          # ./spec/spec_helper.rb:12:in `new_client'                                           
          # ./spec/spec_helper.rb:25:in `block (2 levels) in <top (required)>' 
          # ------------------                              
          # --- Caused by: ---                                                                 
          # Mysql2::Error:                                                     
          #   Unknown database 'test_anno_db'                                                                                
          #   ./vendor/bundle/ruby/2.5.0/gems/mysql2-0.5.3/lib/mysql2/client.rb:90:in `connect'
 ```